### PR TITLE
Reuse connections

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,9 @@ type InsertConfig struct {
 	SleepSeconds           int    `mapstructure:"sleep_seconds"`
 	DataDir                string `mapstructure:"data"`
 	FreeSpaceRequiredBytes int64  `mapstructure:"free_space_required_bytes"`
+	MaxOpenConns           int    `mapstructure:"max_open_conns"`
+	MaxIdleConns           int    `mapstructure:"max_idle_conns"`
+	ConnMaxLifetimeSecs    int    `mapstructure:"conn_max_lifetime"`
 }
 
 type IngestConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20230716120725-531d2d74bc12
 	github.com/jeremywohl/flatten v1.0.1
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/viper v1.16.0
 	github.com/spyzhov/ajson v0.8.0
 	golang.org/x/crypto v0.13.0
@@ -34,7 +35,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/philhofer/fwd v1.1.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.17 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/savsgio/dictpool v0.0.0-20221023140959-7bf2e61cea94 // indirect

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -378,6 +378,10 @@ func (im *Importer) connect() (driver.Conn, error) {
 				Username: im.Config.Clickhouse.Username,
 				Password: im.Config.Clickhouse.Password,
 			},
+			Debug:           false,
+			MaxOpenConns:    im.Config.Insert.MaxOpenConns,
+			MaxIdleConns:    im.Config.Insert.MaxIdleConns,
+			ConnMaxLifetime: time.Second * time.Duration(im.Config.Insert.ConnMaxLifetimeSecs),
 			// ClientInfo: clickhouse.ClientInfo{
 			// 	Products: []struct {
 			// 		Name    string


### PR DESCRIPTION
This change fixes #10.

Memory profiling
```text
Showing nodes accounting for 110.12MB, 100% of 110.12MB total
Showing top 10 nodes out of 38
      flat  flat%   sum%        cum   cum%
   96.46MB 87.59% 87.59%    97.46MB 88.50%  scratchdb/importer.(*Importer).getColumnsLocal
       4MB  3.64% 91.23%        4MB  3.64%  runtime.allocm
       3MB  2.72% 93.95%        3MB  2.72%  github.com/aws/aws-sdk-go/aws/endpoints.init
    1.50MB  1.36% 95.31%     1.50MB  1.36%  runtime.malg
    1.27MB  1.15% 96.47%     1.27MB  1.15%  github.com/valyala/fasthttp/stackless.NewFunc
    1.14MB  1.03% 97.50%     1.14MB  1.03%  github.com/ClickHouse/ch-go/compress.NewWriter
    1.13MB  1.03% 98.53%     1.13MB  1.03%  github.com/ClickHouse/ch-go/proto.NewReader
       1MB  0.91% 99.44%        1MB  0.91%  github.com/spyzhov/ajson.getString
    0.62MB  0.56%   100%     0.62MB  0.56%  github.com/ClickHouse/clickhouse-go/v2/lib/proto.(*Query).Encode
         0     0%   100%     2.89MB  2.63%  github.com/ClickHouse/clickhouse-go/v2.(*clickhouse).Exec
```

![Screenshot from 2023-10-11 05-05-24](https://github.com/scratchdata/ScratchDB/assets/20656657/08cd65dd-372d-4efe-af5a-668041828aff)

