### PR TITLE
make `util.ConfigToStruct` return a pointer

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -24,7 +24,7 @@ func GetDB(config map[string]interface{}) Database {
 
 	switch configType {
 	case "static":
-		return util.ConfigToStruct[*static.StaticDB](config)
+		return util.ConfigToStruct[static.StaticDB](config)
 	default:
 		return nil
 	}

--- a/pkg/destinations/destinations.go
+++ b/pkg/destinations/destinations.go
@@ -15,9 +15,9 @@ func GetDestination(dbConfig models.DatabaseConnection) DatabaseServer {
 
 	switch configType {
 	case "duckdb":
-		return util.ConfigToStruct[*duckdb.DuckDBServer](connectionSettings)
+		return util.ConfigToStruct[duckdb.DuckDBServer](connectionSettings)
 	case "clickhouse":
-		return util.ConfigToStruct[*clickhouse.ClickhouseServer](connectionSettings)
+		return util.ConfigToStruct[clickhouse.ClickhouseServer](connectionSettings)
 	case "memory":
 		return util.ConfigToStruct[memory.MemoryDBServer](connectionSettings)
 	default:

--- a/util/config.go
+++ b/util/config.go
@@ -7,9 +7,9 @@ import (
 
 // Takes an arbitrary map and populates a struct with the fields.
 // Used for transforming configuration files into structs.
-func ConfigToStruct[T any](rawConfig map[string]interface{}) T {
-	var config T
-	if err := mapstructure.Decode(rawConfig, &config); err != nil {
+func ConfigToStruct[T any](rawConfig map[string]interface{}) *T {
+	config := new(T)
+	if err := mapstructure.Decode(rawConfig, config); err != nil {
 		log.Error().Msgf("Error decoding config: %v", err)
 	}
 	return config

--- a/util/config_test.go
+++ b/util/config_test.go
@@ -1,0 +1,28 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestConfigToStruct(t *testing.T) {
+	type T struct {
+		X string `mapstructure:"x"`
+	}
+
+	// make sure a valid value is returned when no config is provided
+	v := ConfigToStruct[T](nil)
+	if v == nil {
+		t.Fatal("ConfigToStruct returned nil")
+	}
+
+	// make sure a valid value is returned when invalid config is provided
+	v = ConfigToStruct[T](map[string]any{"x": 123})
+	if v == nil {
+		t.Fatal("ConfigToStruct returned nil")
+	}
+
+	v = ConfigToStruct[T](map[string]any{"x": "y"})
+	if v.X != "y" {
+		t.Fatalf("Expected y`; Got %#q", v.X)
+	}
+}


### PR DESCRIPTION
The old interface is somewhat error-prone.

Previously, given `ConfigToStruct[*T]`, `nil` would be returned if `rawConfig` was `nil`.
This resulted in `nil` being propagated through the system, eventually causing a random nil pointer crash with no obvious cause.