### PR TITLE
cache DatabaseServers in `destinations.GetDestination`

### DIFF
--- a/cmd/api/query.go
+++ b/cmd/api/query.go
@@ -34,16 +34,14 @@ func (i *API) Query(c *fiber.Ctx) error {
 	}
 
 	// TODO: need some sort of local connection pool or storage
-	connection := destinations.GetDestination(connectionSetting)
-	if connection == nil {
+	connection, err := destinations.GetDestination(connectionSetting)
+	if err != nil {
 		return errors.New("Destination " + connectionSetting.Type + " does not exist")
 	}
 
 	// TODO: use a buffered pipe of some sort to stream results
 	// https://github.com/gofiber/fiber/issues/1034
 	// https://stackoverflow.com/questions/68778961/how-to-configure-the-buffer-size-for-http-responsewriter
-
-	var err error
 
 	switch c.Query("format", "json") {
 	case "json":

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"scratchdata/cmd/api"
 	"scratchdata/config"
 	"scratchdata/pkg/database"
+	"scratchdata/pkg/destinations"
 	"scratchdata/pkg/filestore"
 	dummystore "scratchdata/pkg/filestore/dummy"
 	memorystore "scratchdata/pkg/filestore/memory"
@@ -165,6 +166,10 @@ func main() {
 
 		if err := dataTransport.StopConsumer(); err != nil {
 			log.Info().Err(err).Msg("Cannot stop consumer")
+		}
+
+		if err := destinations.ClearCache(); err != nil {
+			log.Info().Err(err).Msg("Cannot close database servers")
 		}
 	}
 }

--- a/pkg/destinations/clickhouse/clickhouse.go
+++ b/pkg/destinations/clickhouse/clickhouse.go
@@ -34,8 +34,7 @@ type ClickhouseServer struct {
 	conn driver.Conn
 }
 
-func (s *ClickhouseServer) openConn() (driver.Conn, error) {
-
+func openConn(s *ClickhouseServer) (driver.Conn, error) {
 	options := &clickhouse.Options{
 		Addr: []string{fmt.Sprintf("%s:%d", s.Host, s.TCPPort)},
 		Auth: clickhouse.Auth{
@@ -76,6 +75,10 @@ func (s *ClickhouseServer) openConn() (driver.Conn, error) {
 	return conn, nil
 }
 
+func (s *ClickhouseServer) Close() error {
+	return s.conn.Close()
+}
+
 func (s *ClickhouseServer) httpQuery(query string) (io.ReadCloser, error) {
 	url := fmt.Sprintf("%s://%s:%d", s.HTTPProtocol, s.Host, s.HTTPPort)
 
@@ -101,11 +104,10 @@ func (s *ClickhouseServer) httpQuery(query string) (io.ReadCloser, error) {
 
 func OpenServer(settings map[string]any) (*ClickhouseServer, error) {
 	srv := util.ConfigToStruct[ClickhouseServer](settings)
-	conn, err := srv.openConn()
+	conn, err := openConn(srv)
 	if err != nil {
-		return nil, fmt.Errorf("Open: %w", err)
+		return nil, fmt.Errorf("OpenServer: %w", err)
 	}
 	srv.conn = conn
-
 	return srv, nil
 }

--- a/pkg/destinations/clickhouse/clickhouse_test.go
+++ b/pkg/destinations/clickhouse/clickhouse_test.go
@@ -1,0 +1,103 @@
+package clickhouse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/ory/dockertest/v3"
+)
+
+func TestQueue(t *testing.T) {
+	database := "testdb"
+	username := "testuser"
+	password := ""
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatalf("Create pool: %s", err)
+	}
+	if err := pool.Client.Ping(); err != nil {
+		t.Fatalf("Ping Docker: %s", err)
+	}
+	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "clickhouse/clickhouse-server",
+		Env: []string{
+			"CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1",
+			"CLICKHOUSE_DB=" + database,
+			"CLICKHOUSE_USER=" + username,
+			"CLICKHOUSE_PASSWORD" + password,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run container: %s", err)
+	}
+	t.Cleanup(func() {
+		if err := pool.Purge(resource); err != nil {
+			t.Logf("Purge resource: %s", err)
+		}
+	})
+
+	addr := resource.GetHostPort("9000/tcp")
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("Cannot split addr: %s: %s", addr, err)
+	}
+	tcpPort, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("Cannot parse port: %s: %s", port, err)
+	}
+	port = resource.GetPort("8123/tcp")
+	httpPort, err := strconv.Atoi(port)
+	if err != nil {
+		t.Fatalf("Cannot parse port: %s: %s", port, err)
+	}
+
+	dbSettings := map[string]any{
+		"protocol":  "http",
+		"host":      host,
+		"http_port": httpPort,
+		"tcp_port":  tcpPort,
+		"username":  username,
+		"password":  password,
+		"database":  database,
+	}
+	var db *ClickhouseServer
+	err = pool.Retry(func() error {
+		db, err = OpenServer(dbSettings)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("Cannot open server: %s", err)
+	}
+
+	// the implementation is currently incomplete so we manually create the table
+	// columns will be added, so just add a dummy column
+	err = db.conn.Exec(context.Background(), `
+		create table if not exists `+database+`.tbl (_ Int) engine=Memory
+	`)
+	if err != nil {
+		t.Fatalf("Cannot create table: %s", err)
+	}
+
+	if err := db.InsertBatchFromNDJson("tbl", strings.NewReader(`{"msg":"hello world"}`)); err != nil {
+		t.Fatalf("Cannot insert JSON: %s", err)
+	}
+	buf := &bytes.Buffer{}
+	if err := db.QueryJSON(`select * from tbl`, buf); err != nil {
+		t.Fatalf("Cannot query JSON: %s", err)
+	}
+	type Msg struct{ Msg string }
+	vals := []Msg{}
+	if err := json.Unmarshal(buf.Bytes(), &vals); err != nil {
+		t.Fatalf("Cannot decode JSON: %s", err)
+	}
+	exp := Msg{Msg: "hello world"}
+	if len(vals) != 1 || vals[0] != exp {
+		t.Fatalf(`Expected [%+v]; Got %+v`, exp, vals)
+	}
+}

--- a/pkg/destinations/clickhouse/insert.go
+++ b/pkg/destinations/clickhouse/insert.go
@@ -117,16 +117,7 @@ func (s *ClickhouseServer) createColumnsWithTypes(table string, columns map[stri
 
 	log.Trace().Msg(sql)
 
-	// Get clickhouse server conn
-	conn, err := s.createConn()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
-	err = conn.Exec(context.TODO(), sql)
-
-	return err
+	return s.conn.Exec(context.TODO(), sql)
 }
 
 func (s *ClickhouseServer) getClickhouseTypes(table string) (map[string]string, error) {
@@ -245,15 +236,8 @@ func (s *ClickhouseServer) insertData(file io.ReadSeeker, table string, columns 
 	}
 	// defer file.Close()
 
-	// Get clickhouse server conn
-	conn, err := s.createConn()
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-
 	// Begin batch
-	batch, err := conn.PrepareBatch(context.Background(), insertSql)
+	batch, err := s.conn.PrepareBatch(context.Background(), insertSql)
 	if err != nil {
 		log.Err(err).Msg("unable to initiate batch query")
 		return err

--- a/pkg/destinations/destinations.go
+++ b/pkg/destinations/destinations.go
@@ -1,6 +1,7 @@
 package destinations
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"scratchdata/models"
@@ -11,20 +12,64 @@ import (
 )
 
 var (
-	destinationCache = struct {
-		sync.RWMutex
-		m map[string]DatabaseServer
-	}{
-		m: map[string]DatabaseServer{},
-	}
+	destinations = &destinationsCache{}
 )
 
-func deriveDatabaseConnectionKey(dbConfig models.DatabaseConnection) string {
+type destinationsCache struct {
+	// the number of different db connections should be small
+	// and they are openend only once, so there shouldn't be much, if any contention
+	//
+	// if there is a performance issue, a slightly more complex locking scheme might be required:
+	// an exclusive lock around the whole cache blocks every caller to GetDestinations
+	// until the connection is opened (and pinged)
+	// so we'd instead need to lock only the relevant cache key.
+	mu sync.Mutex
+	m  map[string]DatabaseServer
+}
+
+func (dc *destinationsCache) Get(dbConfig models.DatabaseConnection) (DatabaseServer, error) {
+	key := dc.deriveKey(dbConfig)
+
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	if db, ok := dc.m[key]; ok {
+		return db, nil
+	}
+
+	db, err := dc.openServer(dbConfig.Type, dbConfig.ConnectionSettings)
+	if err != nil {
+		return nil, fmt.Errorf("GetDestination: %s: %w", dbConfig.Type, err)
+	}
+
+	if dc.m == nil {
+		dc.m = map[string]DatabaseServer{}
+	}
+	dc.m[key] = db
+	return db, nil
+}
+
+func (dc *destinationsCache) Clear() error {
+	dc.mu.Lock()
+	defer dc.mu.Unlock()
+
+	var errs []error
+	for _, db := range dc.m {
+		if err := db.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	clear(dc.m)
+	return errors.Join(errs...)
+
+}
+
+func (dc *destinationsCache) deriveKey(dbConfig models.DatabaseConnection) string {
 	// if ID isn't enough, we can also marshal dbConfig using a canonical/deterministic JSON encoder
 	return dbConfig.ID
 }
 
-func openDBServer(dbType string, settings map[string]any) (DatabaseServer, error) {
+func (dc *destinationsCache) openServer(dbType string, settings map[string]any) (DatabaseServer, error) {
 	switch dbType {
 	case "duckdb":
 		return duckdb.OpenServer(settings)
@@ -37,33 +82,23 @@ func openDBServer(dbType string, settings map[string]any) (DatabaseServer, error
 	}
 }
 
+// GetDestination returns a cached Destination corresponding to dbConfig
 func GetDestination(dbConfig models.DatabaseConnection) (DatabaseServer, error) {
-	key := deriveDatabaseConnectionKey(dbConfig)
+	return destinations.Get(dbConfig)
+}
 
-	destinationCache.RLock()
-	db, ok := destinationCache.m[key]
-	destinationCache.RUnlock()
-	if ok {
-		return db, nil
-	}
-
-	destinationCache.Lock()
-	defer destinationCache.Unlock()
-
-	if db, ok := destinationCache.m[key]; ok {
-		return db, nil
-	}
-
-	db, err := openDBServer(dbConfig.Type, dbConfig.ConnectionSettings)
-	if err != nil {
-		return nil, fmt.Errorf("GetDestination: %s: %w", dbConfig.Type, err)
-	}
-
-	destinationCache.m[key] = db
-	return db, nil
+// ClearCache closes all cached Destinations and clears the cache.
+//
+// A combined error is returned for all destinations for which close fails.
+func ClearCache() error {
+	return destinations.Clear()
 }
 
 type DatabaseServer interface {
 	InsertBatchFromNDJson(table string, input io.ReadSeeker) error
 	QueryJSON(query string, writer io.Writer) error
+
+	// Close closes the database server and prevents new operations from starting.
+	// If there are on-going operations, Close waits for them to complete before returning.
+	Close() error
 }

--- a/pkg/destinations/destinations.go
+++ b/pkg/destinations/destinations.go
@@ -1,28 +1,66 @@
 package destinations
 
 import (
+	"fmt"
 	"io"
 	"scratchdata/models"
 	"scratchdata/pkg/destinations/clickhouse"
 	"scratchdata/pkg/destinations/duckdb"
 	"scratchdata/pkg/destinations/memory"
-	"scratchdata/util"
+	"sync"
 )
 
-func GetDestination(dbConfig models.DatabaseConnection) DatabaseServer {
-	configType := dbConfig.Type
-	connectionSettings := dbConfig.ConnectionSettings
-
-	switch configType {
-	case "duckdb":
-		return util.ConfigToStruct[duckdb.DuckDBServer](connectionSettings)
-	case "clickhouse":
-		return util.ConfigToStruct[clickhouse.ClickhouseServer](connectionSettings)
-	case "memory":
-		return util.ConfigToStruct[memory.MemoryDBServer](connectionSettings)
-	default:
-		return nil
+var (
+	destinationCache = struct {
+		sync.RWMutex
+		m map[string]DatabaseServer
+	}{
+		m: map[string]DatabaseServer{},
 	}
+)
+
+func deriveDatabaseConnectionKey(dbConfig models.DatabaseConnection) string {
+	// if ID isn't enough, we can also marshal dbConfig using a canonical/deterministic JSON encoder
+	return dbConfig.ID
+}
+
+func openDBServer(dbType string, settings map[string]any) (DatabaseServer, error) {
+	switch dbType {
+	case "duckdb":
+		return duckdb.OpenServer(settings)
+	case "clickhouse":
+		return clickhouse.OpenServer(settings)
+	case "memory":
+		return memory.OpenServer(settings), nil
+	default:
+		return nil, fmt.Errorf("GetDestination: Unsupported database type: %s", dbType)
+	}
+}
+
+func GetDestination(dbConfig models.DatabaseConnection) (DatabaseServer, error) {
+	key := deriveDatabaseConnectionKey(dbConfig)
+
+	destinationCache.RLock()
+	db, ok := destinationCache.m[key]
+	destinationCache.RUnlock()
+	if ok {
+		return db, nil
+	}
+
+	destinationCache.Lock()
+	defer destinationCache.Unlock()
+
+	if db, ok := destinationCache.m[key]; ok {
+		return db, nil
+	}
+
+	db, err := openDBServer(dbConfig.Type, dbConfig.ConnectionSettings)
+	if err != nil {
+		return nil, fmt.Errorf("GetDestination: %s: %w", dbConfig.Type, err)
+	}
+
+	destinationCache.m[key] = db
+	return db, nil
 }
 
 type DatabaseServer interface {

--- a/pkg/destinations/destinations_test.go
+++ b/pkg/destinations/destinations_test.go
@@ -1,0 +1,49 @@
+package destinations
+
+import (
+	"errors"
+	"scratchdata/models"
+	"scratchdata/pkg/destinations/memory"
+	"testing"
+)
+
+func TestGetDestinations(t *testing.T) {
+	cache := &destinationsCache{}
+	db1, err := cache.Get(models.DatabaseConnection{ID: "id-a", Type: "memory"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	db2, err := cache.Get(models.DatabaseConnection{ID: "id-a", Type: "memory"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db2 != db1 {
+		t.Fatal("Cache failed to return the same instance on the second call")
+	}
+
+	db3, err := cache.Get(models.DatabaseConnection{ID: "id-b", Type: "memory"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db3 == db2 {
+		t.Fatal("Cache failed to return a new instance")
+	}
+
+	if err := cache.Clear(); err != nil {
+		t.Fatal(err)
+	}
+
+	// MemoryDBServer returns ErrClosed if it's closed twice
+	// so use that fact to detect whether cache.Clear() called Close()
+	if err := db3.(*memory.MemoryDBServer).Close(); !errors.Is(err, memory.ErrClosed) {
+		t.Fatalf("Cache failed to close cached instance: Expected %v; Got %v", memory.ErrClosed, err)
+	}
+
+	db4, err := cache.Get(models.DatabaseConnection{ID: "id-b", Type: "memory"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db4 == db3 {
+		t.Fatal("Failed to clear cache; new db4 == old db3")
+	}
+}

--- a/pkg/destinations/duckdb/duckdb.go
+++ b/pkg/destinations/duckdb/duckdb.go
@@ -2,7 +2,10 @@ package duckdb
 
 import (
 	"context"
+	"database/sql"
 	"database/sql/driver"
+	"fmt"
+	"scratchdata/util"
 
 	"github.com/marcboeker/go-duckdb"
 	_ "github.com/marcboeker/go-duckdb"
@@ -18,6 +21,8 @@ type DuckDBServer struct {
 	Region          string `mapstructure:"region"`
 	S3Prefix        string `mapstructure:"s3_prefix"`
 	Endpoint        string `mapstructure:"endpoint"`
+
+	db *sql.DB
 }
 
 var jsonToDuck = map[string]string{
@@ -53,4 +58,14 @@ func (s *DuckDBServer) getConnector() (driver.Connector, error) {
 	}
 
 	return connector, err
+}
+
+func OpenServer(settings map[string]any) (*DuckDBServer, error) {
+	srv := util.ConfigToStruct[DuckDBServer](settings)
+	connector, err := srv.getConnector()
+	if err != nil {
+		return nil, fmt.Errorf("OpenServer: %w", err)
+	}
+	srv.db = sql.OpenDB(connector)
+	return srv, nil
 }

--- a/pkg/destinations/duckdb/insert.go
+++ b/pkg/destinations/duckdb/insert.go
@@ -84,23 +84,12 @@ func (s *DuckDBServer) InsertBatchFromNDJson(table string, input io.ReadSeeker) 
 		return err
 	}
 
-	connector, err := s.getConnector()
+	err = s.createTable(table, s.db)
 	if err != nil {
 		return err
 	}
 
-	db := sql.OpenDB(connector)
-	if err != nil {
-		return err
-	}
-	defer db.Close()
-
-	err = s.createTable(table, db)
-	if err != nil {
-		return err
-	}
-
-	err = s.createColumns(table, jsonTypes, db)
+	err = s.createColumns(table, jsonTypes, s.db)
 	if err != nil {
 		return err
 	}
@@ -119,7 +108,7 @@ func (s *DuckDBServer) InsertBatchFromNDJson(table string, input io.ReadSeeker) 
 		return err
 	}
 
-	err = s.insertFromS3(table, tempFile, db)
+	err = s.insertFromS3(table, tempFile, s.db)
 	if err != nil {
 		return err
 	}

--- a/pkg/destinations/duckdb/query.go
+++ b/pkg/destinations/duckdb/query.go
@@ -1,7 +1,6 @@
 package duckdb
 
 import (
-	"database/sql"
 	"io"
 	"scratchdata/util"
 )
@@ -9,15 +8,7 @@ import (
 func (s *DuckDBServer) QueryJSON(query string, writer io.Writer) error {
 	sanitized := util.TrimQuery(query)
 
-	connector, err := s.getConnector()
-	if err != nil {
-		return err
-	}
-
-	db := sql.OpenDB(connector)
-	defer db.Close()
-
-	rows, err := db.Query("DESCRIBE " + sanitized)
+	rows, err := s.db.Query("DESCRIBE " + sanitized)
 	if err != nil {
 		return err
 	}
@@ -40,7 +31,7 @@ func (s *DuckDBServer) QueryJSON(query string, writer io.Writer) error {
 
 	rows.Close()
 
-	rows, err = db.Query("SELECT to_json(COLUMNS(*)) FROM (" + sanitized + ")")
+	rows, err = s.db.Query("SELECT to_json(COLUMNS(*)) FROM (" + sanitized + ")")
 	if err != nil {
 		return err
 	}

--- a/pkg/destinations/memory/memory_test.go
+++ b/pkg/destinations/memory/memory_test.go
@@ -13,7 +13,7 @@ func TestMemoryDBServer(t *testing.T) {
 	tblOutput := []byte(`[{"msg1":"hello"},{"msg2":"world"}]`)
 	defOutput := []byte(`[{"hello":"world"}]`)
 	noOutput := []byte(`[]`)
-	dest := MemoryDBServer{}
+	dest := OpenServer(nil)
 
 	if err := dest.InsertBatchFromNDJson("tbl", bytes.NewReader(tblInput)); err != nil {
 		t.Fatalf("Insert failed: %s", err)

--- a/pkg/transport/memory/memory.go
+++ b/pkg/transport/memory/memory.go
@@ -89,9 +89,14 @@ func (s *MemoryTransport) StartConsumer() error {
 					for tableName, buf := range tables {
 						if buf.Len() > 0 {
 							connInfo := s.db.GetDatabaseConnection(dbID)
-							conn := destinations.GetDestination(connInfo)
+							conn, err := destinations.GetDestination(connInfo)
+							if err != nil {
+								log.Error().Err(err).Bytes("data", buf.Bytes()).Str("db", dbID).Str("table", tableName).Msg("Unable to get Destination")
+								buf.Reset()
+								continue
+							}
 							r := bytes.NewReader(buf.Bytes())
-							err := conn.InsertBatchFromNDJson(tableName, r)
+							err = conn.InsertBatchFromNDJson(tableName, r)
 							if err != nil {
 								log.Error().Err(err).Bytes("data", buf.Bytes()).Str("db", dbID).Str("table", tableName).Msg("Unable to save data to db")
 							}

--- a/pkg/transport/queuestorage/queuestorage.go
+++ b/pkg/transport/queuestorage/queuestorage.go
@@ -179,9 +179,9 @@ func (s *QueueStorage) insertMessage(msg models.FileUploadMessage) (retErr error
 		return fmt.Errorf("QueueStorage.insertMessage: Cannot get database connection for '%s'", dbID)
 	}
 
-	dest := destinations.GetDestination(conn)
-	if dest == nil {
-		return fmt.Errorf("QueueStorage.insertMessage: Cannot get destination for '%s/%s'", dbID, conn.ID)
+	dest, err := destinations.GetDestination(conn)
+	if err != nil {
+		return fmt.Errorf("QueueStorage.insertMessage: Cannot get destination for '%s/%s': %w", dbID, conn.ID, err)
 	}
 
 	fn := filepath.Join(s.ConsumerDataDir, filepath.Base(msg.Path))


### PR DESCRIPTION
GetDestination caches the DatabaseServer object if successfully opened.

The driver.Conn and sql.DB are stored on the Clickhouse and DubDB objects respectively since they're not a single connection, but a pool.

MaxIdleConns, and other settings will likely need to be tweaked, but this prototype should be a fully working demonstration.

implements  #90