### PR TITLE
Add sample value for CRSF token in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,7 @@ database:
 
 dashboard:
   enabled: true
+  csrf_secret: PlaceHolderForLocalUse
 
 destinations:
   - type: duckdb


### PR DESCRIPTION
This PR adds a placeholder value for the CSRF token in the sample config.